### PR TITLE
feat: ci-cd pipeline 기존 도커 컨테이너 정지 스크립트 수정

### DIFF
--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -38,7 +38,7 @@ jobs:
           # PRODUCTION 이면 host port 8081 사용
           script: |
             docker pull ${{ secrets.DOCKER_USERNAME }}/board-prod:${{ github.run_number }}
-            docker stop $(docker ps -a -q --filter ancestor=${{ secrets.DOCKER_USERNAME }}/board-prod)
+            docker stop $(docker ps -a --format "{{.ID}}\t{{.Image}}" | grep "${{ secrets.DOCKER_USERNAME }}/board-prod" | cut -f1) 
             docker run -d -p 80:8080 \
               --log-driver=awslogs \
               --log-opt awslogs-region=ap-northeast-2 \

--- a/.github/workflows/ci-cd-sandbox.yml
+++ b/.github/workflows/ci-cd-sandbox.yml
@@ -37,8 +37,7 @@ jobs:
           password: ${{ secrets.BOL_API_SERVER_PASSWORD }}
           script: |
             docker pull ${{ secrets.DOCKER_USERNAME }}/board:${{ github.run_number }}
-            docker stop $(docker ps -a -q)
-            docker stop $(docker ps -a -q --filter ancestor=${{ secrets.DOCKER_USERNAME }}/board)
+            docker stop $(docker ps -a --format "{{.ID}}\t{{.Image}}" | grep "${{ secrets.DOCKER_USERNAME }}/board" | cut -f1)
             docker run -d -p 80:8080 ${{ secrets.DOCKER_USERNAME }}/board:${{ github.run_number }}
             docker rm $(docker ps --filter 'status=exited' -a -q)
             docker image prune -a -f


### PR DESCRIPTION
### Reference
- [Jira Ticket](https://yapp22-aos2.atlassian.net/browse/BOL-)

현재 ci, cd 파이프라인 스크립트 중 기존 docker container 컨테이너를 stop 시키는 부분이 있습니다.
기존에는 `docker ps` filter 옵션으로 컨테이너 네임(board...)을 검색해서 해당되는 컨테이너들을 stop 시키려고 했는데요.
요게 태그 네임이 별도로 달리는 경우 동작이 안 되더라구요.

즉 `board-prod:latest` 는 `docker ps --filter board-prod` 로 검색이 되지만, `board-prod:4` 는 검색이 안 됐습니다.
`docker ps --filter board-prod:4` 처럼 태그까지 붙여줘야 검색이 되어요. (기존에는 태그가 전부 latest 였음)

docker ps filter 대신 grep 을 사용하도록 수정하여 태그 네임이 별도로 달리는 경우에도 동작하도록 수정했어요.


### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)  
